### PR TITLE
Implemented get book by ID endpoint

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -47,6 +47,17 @@ async def create_book(book: Book):
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
+# implementation of missing endpoint
+
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book(book_id: int) -> Book:
+    book = db.get_book(book_id)
+    if not book:
+        return JSONResponse(
+            status_code=status.HTTP_404_NOT_FOUND,
+            content={"detail": "Book not found"}
+        )
+    return book
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:


### PR DESCRIPTION
**Description:**

This PR introduces the missing endpoint for fetching a single book's details via a GET request. The new endpoint lets users retrieve information about a specific book by providing its ID.

**Changes:**
- Added the `GET /api/v1/books/{id}` endpoint.
- This endpoint returns the book's details with the given `id`.

**Example Request:**
```
GET /api/v1/books/1
```

**Example Response:**
```json
{
    "id": 1,
    "title": "The Hobbit",
    "author": "J.R.R. Tolkien",
    "publication_year": 1937,
    "genre": "Science Fiction"
}
```

**Reasoning:**
This endpoint fills the gap for retrieving individual book details, which enhances the API's functionality and provides users with better access to book information.
